### PR TITLE
Add initial ABS to Datawrapper workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,19 @@
 # api_dw_contentmachine
 
-The purpose of this repository is to create an environment in R which can pull in data from the ABS using an API key, and generate graphs in Datawrapper using a different API key. 
+The goal of this repository is to demonstrate how to collect data from the Australian Bureau of Statistics (ABS) API and upload that data to Datawrapper for chart creation.  Two different API keys are required:
 
-To prove this concept I just want to start by pulling in national accounts data from the ABS, and generating some graphs, 
-Eventually I will refine it further or it may plug straight into CANVA. 
+- `ABS_API_KEY` – used by the `readabs` package to access the ABS API
+- `DW_API_KEY` – used to authenticate with Datawrapper
 
+## Example script
+
+The `national_accounts_to_dw.R` script shows a simple workflow that downloads the national accounts time series and publishes it to Datawrapper.  The script expects the API keys to be available as environment variables.
+
+```r
+Sys.setenv(ABS_API_KEY = "your-abs-key")
+Sys.setenv(DW_API_KEY = "your-datawrapper-key")
+
+source("national_accounts_to_dw.R")
+```
+
+Running the script will create (or update) a Datawrapper chart with the latest quarterly GDP data.

--- a/national_accounts_to_dw.R
+++ b/national_accounts_to_dw.R
@@ -1,0 +1,49 @@
+# Fetch GDP data from the ABS and publish to Datawrapper
+
+library(readabs)
+library(dplyr)
+library(httr)
+library(readr)
+
+abs_key <- Sys.getenv("ABS_API_KEY")
+if (abs_key != "") {
+  set_abs_key(abs_key)
+}
+
+dw_key <- Sys.getenv("DW_API_KEY")
+if (dw_key == "") {
+  stop("DW_API_KEY environment variable not set")
+}
+
+# GDP chain volume measure, seasonally adjusted (series id may need updating)
+gdp <- read_abs(series_id = "A2305846X") %>%
+  select(date, value)
+
+# Prepare Datawrapper request helpers
+base_url <- "https://api.datawrapper.de/v3"
+header <- add_headers(Authorization = paste("Bearer", dw_key))
+
+# Create a new chart
+create_res <- POST(
+  url = paste0(base_url, "/charts"),
+  header,
+  body = list(title = "Australian GDP", type = "d3-lines"),
+  encode = "json"
+)
+chart_id <- content(create_res)$id
+
+# Upload data to the chart
+csv_file <- tempfile(fileext = ".csv")
+write_csv(gdp, csv_file)
+
+PUT(
+  url = paste0(base_url, "/charts/", chart_id, "/data"),
+  header,
+  body = list(file = upload_file(csv_file))
+)
+
+# Publish the chart
+POST(
+  url = paste0(base_url, "/charts/", chart_id, "/publish"),
+  header
+)


### PR DESCRIPTION
## Summary
- document required API keys
- add example R script to fetch ABS national accounts data and upload to Datawrapper

## Testing
- `Rscript --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fb73f3cd8832daf6446a749cfc68d